### PR TITLE
Add initial Next.js frontend scaffold

### DIFF
--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,7 @@
+node_modules
+.next
+out
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -1,14 +1,32 @@
 # Frontend
 
-This directory is reserved for the PersonaFlow frontend application.
+PersonaFlow's frontend is a minimal Next.js + TypeScript app for the MVP landing page and upcoming voice session flow.
 
-Planned stack:
-- Next.js
-- TypeScript
+## What is included
 
-Expected responsibility:
-- voice session UI
-- post-session results screen
-- communication with the backend API
+- Next.js App Router scaffold
+- global layout and metadata
+- single landing page with PersonaFlow branding
+- placeholder Start Session action for future session flow work
+- lightweight CSS styling with no extra UI framework
 
-The actual app scaffold should be added in the dedicated frontend setup issue.
+## Local development
+
+Prerequisite:
+- Node.js 20+ and npm
+
+Run locally:
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+Then open `http://localhost:3000`.
+
+## Notes
+
+- No frontend environment variables are required for this scaffold.
+- The Start Session button is intentionally a placeholder and does not call the backend yet.
+- Session, microphone, and results flows should be added in follow-up issues.

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -1,0 +1,167 @@
+:root {
+  color-scheme: light;
+  --bg: #f7f4ec;
+  --bg-accent: #efe1c7;
+  --surface: rgba(255, 251, 243, 0.88);
+  --surface-strong: #fffaf0;
+  --text: #1f1a13;
+  --muted: #665a4a;
+  --border: rgba(92, 73, 44, 0.16);
+  --shadow: 0 22px 60px rgba(57, 40, 16, 0.12);
+  --brand: #b65c2e;
+  --brand-strong: #8f431d;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html {
+  min-height: 100%;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  font-family: Georgia, "Times New Roman", serif;
+  color: var(--text);
+  background:
+    radial-gradient(circle at top, rgba(255, 255, 255, 0.85), transparent 38%),
+    linear-gradient(160deg, var(--bg) 0%, var(--bg-accent) 100%);
+}
+
+button,
+input,
+textarea,
+select {
+  font: inherit;
+}
+
+.page-shell {
+  min-height: 100vh;
+  display: grid;
+  place-items: center;
+  padding: 32px 20px;
+}
+
+.hero-card {
+  width: min(980px, 100%);
+  display: grid;
+  grid-template-columns: 1.3fr 0.9fr;
+  gap: 24px;
+  padding: 28px;
+  border: 1px solid var(--border);
+  border-radius: 28px;
+  background: var(--surface);
+  box-shadow: var(--shadow);
+  backdrop-filter: blur(8px);
+}
+
+.hero-copy,
+.hero-panel {
+  border-radius: 22px;
+}
+
+.hero-copy {
+  padding: 20px 10px 20px 6px;
+}
+
+.eyebrow {
+  margin: 0 0 14px;
+  font-size: 0.82rem;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  color: var(--brand-strong);
+}
+
+h1 {
+  margin: 0;
+  font-size: clamp(3rem, 8vw, 5.5rem);
+  line-height: 0.95;
+  letter-spacing: -0.05em;
+}
+
+.lede {
+  max-width: 34rem;
+  margin: 20px 0 0;
+  font-size: 1.08rem;
+  line-height: 1.7;
+  color: var(--muted);
+}
+
+.hero-panel {
+  padding: 24px;
+  background: var(--surface-strong);
+  border: 1px solid rgba(92, 73, 44, 0.1);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  gap: 18px;
+}
+
+.panel-chip {
+  width: fit-content;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: rgba(182, 92, 46, 0.12);
+  color: var(--brand-strong);
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.feature-list {
+  margin: 0;
+  padding-left: 18px;
+  display: grid;
+  gap: 10px;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.start-button {
+  border: 0;
+  border-radius: 999px;
+  padding: 14px 20px;
+  background: linear-gradient(135deg, var(--brand) 0%, var(--brand-strong) 100%);
+  color: #fffaf5;
+  font-size: 1rem;
+  font-weight: 700;
+  cursor: pointer;
+  box-shadow: 0 14px 32px rgba(143, 67, 29, 0.28);
+  transition:
+    transform 160ms ease,
+    box-shadow 160ms ease;
+}
+
+.start-button:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 16px 36px rgba(143, 67, 29, 0.34);
+}
+
+.button-note {
+  margin: 0;
+  font-size: 0.92rem;
+  color: var(--muted);
+}
+
+@media (max-width: 760px) {
+  .hero-card {
+    grid-template-columns: 1fr;
+    padding: 20px;
+  }
+
+  .hero-copy {
+    padding: 4px;
+  }
+
+  .hero-panel {
+    padding: 20px;
+  }
+
+  .lede {
+    font-size: 1rem;
+  }
+}

--- a/frontend/app/layout.tsx
+++ b/frontend/app/layout.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from "next";
+import "./globals.css";
+
+export const metadata: Metadata = {
+  title: "PersonaFlow",
+  description:
+    "Voice-first English learning focused on preserving personal tone and self-expression.",
+};
+
+type RootLayoutProps = {
+  children: React.ReactNode;
+};
+
+export default function RootLayout({ children }: RootLayoutProps) {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,0 +1,30 @@
+export default function HomePage() {
+  return (
+    <main className="page-shell">
+      <section className="hero-card">
+        <div className="hero-copy">
+          <p className="eyebrow">Voice-first English practice</p>
+          <h1>PersonaFlow</h1>
+          <p className="lede">
+            Build an English voice that still feels like you. PersonaFlow turns
+            natural conversation into reusable phrase cards that reflect your
+            tone, not generic textbook lines.
+          </p>
+        </div>
+
+        <div className="hero-panel" aria-label="Product summary">
+          <div className="panel-chip">MVP</div>
+          <ul className="feature-list">
+            <li>Speak naturally first</li>
+            <li>Review personal phrases after the session</li>
+            <li>No translation-oriented workflow</li>
+          </ul>
+          <button className="start-button" type="button">
+            Start Session
+          </button>
+          <p className="button-note">Session flow placeholder for the next issue.</p>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/frontend/next-env.d.ts
+++ b/frontend/next-env.d.ts
@@ -1,0 +1,4 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// This file is managed by Next.js.

--- a/frontend/next.config.mjs
+++ b/frontend/next.config.mjs
@@ -1,0 +1,6 @@
+/** @type {import("next").NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+export default nextConfig;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "personaflow-frontend",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "^14.2.0",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1"
+  },
+  "devDependencies": {
+    "@types/node": "^20.17.0",
+    "@types/react": "^18.3.12",
+    "@types/react-dom": "^18.3.1",
+    "typescript": "^5.6.3"
+  }
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "target": "ES2017",
+    "lib": ["dom", "dom.iterable", "esnext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
Summary
- scaffolded the `frontend` Next.js app with metadata, layout, page, global styling, build scripts, and configs so PersonaFlow has a running landing view with a Start Session placeholder
- refreshed `frontend/README.md` with what’s included, how to run locally (`npm install`, `npm run dev`), and intentional scope notes/assumptions about placeholder flows
- added `.gitignore` plus typography-friendly, light-touch CSS that showcases PersonaFlow branding without translation cues
- assumed the Start Session button is inert for now and that no backend/session wiring is required yet

Testing
- Not run (not requested)

Suggested follow-up issues
- hook the Start Session button into the upcoming session flow + backend once the API exists
- add microphone capture + transcript persistence matching the MVP scope
- build the post-session phrase card review screen