### PR TITLE
Add start session API and frontend flow

### DIFF
--- a/backend/app/api/routes/sessions.py
+++ b/backend/app/api/routes/sessions.py
@@ -1,4 +1,53 @@
-from fastapi import APIRouter
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from fastapi import APIRouter, Body, Depends, status
+from pydantic import BaseModel, Field
+
+from app.repositories.sessions import SessionRepository
+
+
+class StartSessionRequest(BaseModel):
+    source_language: str = Field(default="ja")
+    target_language: str = Field(default="en")
+
+
+class StartSessionResponse(BaseModel):
+    session_id: str
+    status: str
+    started_at: str
 
 
 router = APIRouter(prefix="/sessions", tags=["sessions"])
+
+
+def get_session_repository() -> SessionRepository:
+    return SessionRepository()
+
+
+@router.post("/start", response_model=StartSessionResponse, status_code=status.HTTP_201_CREATED)
+def start_session(
+    payload: StartSessionRequest | None = Body(default=None),
+    repository: SessionRepository = Depends(get_session_repository),
+) -> StartSessionResponse:
+    request = payload or StartSessionRequest()
+    session_id = str(uuid4())
+    started_at = datetime.now(timezone.utc).isoformat()
+    session_status = "started"
+
+    repository.create_session(
+        session_id,
+        {
+            "user_id": "anonymous",
+            "source_language": request.source_language,
+            "target_language": request.target_language,
+            "status": session_status,
+            "started_at": started_at,
+        },
+    )
+
+    return StartSessionResponse(
+        session_id=session_id,
+        status=session_status,
+        started_at=started_at,
+    )

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,4 +1,5 @@
 from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
 import uvicorn
 
 from app.api.router import api_router
@@ -9,6 +10,13 @@ def create_app() -> FastAPI:
     settings = get_settings()
 
     app = FastAPI(title=settings.app_name)
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["*"],
+        allow_credentials=False,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
     app.include_router(api_router)
 
     return app

--- a/backend/app/repositories/sessions.py
+++ b/backend/app/repositories/sessions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from typing import Any
 
 from app.core.firestore import get_firestore_client
@@ -36,9 +37,10 @@ class SessionRepository:
         return self.get_session_ref(session_id).collection(PHRASE_CARDS_SUBCOLLECTION)
 
     def create_session(self, session_id: str, payload: dict[str, object]) -> None:
-        raise NotImplementedError(
-            "Session persistence will be implemented in a future session issue."
-        )
+        session_doc = self.build_session_doc(session_id)
+        session_doc.update(payload)
+        session_doc.setdefault("started_at", datetime.now(timezone.utc).isoformat())
+        self.get_session_ref(session_id).set(session_doc)
 
     def add_transcript_entry(
         self, session_id: str, entry_id: str, payload: dict[str, object]

--- a/backend/tests/test_firestore_scaffold.py
+++ b/backend/tests/test_firestore_scaffold.py
@@ -50,3 +50,29 @@ class FirestoreScaffoldTests(unittest.TestCase):
             database="persona-db",
         )
         self.assertIs(client, fake_client)
+
+    def test_create_session_persists_document(self) -> None:
+        session_ref = Mock()
+        collection_ref = Mock()
+        collection_ref.document.return_value = session_ref
+        client = Mock()
+        client.collection.return_value = collection_ref
+        repository = SessionRepository(client=client)
+
+        repository.create_session(
+            "session-123",
+            {
+                "status": "started",
+                "started_at": "2026-03-13T10:00:00+00:00",
+            },
+        )
+
+        client.collection.assert_called_once_with("sessions")
+        collection_ref.document.assert_called_once_with("session-123")
+        session_ref.set.assert_called_once_with(
+            {
+                "session_id": "session-123",
+                "status": "started",
+                "started_at": "2026-03-13T10:00:00+00:00",
+            }
+        )

--- a/backend/tests/test_sessions_api.py
+++ b/backend/tests/test_sessions_api.py
@@ -1,0 +1,63 @@
+import unittest
+from unittest.mock import Mock
+
+try:
+    from fastapi.testclient import TestClient
+
+    from app.api.routes.sessions import get_session_repository
+    from app.main import create_app
+except ModuleNotFoundError:
+    TestClient = None
+    get_session_repository = None
+    create_app = None
+
+
+@unittest.skipUnless(TestClient is not None, "fastapi is not installed in the test environment")
+class SessionApiTests(unittest.TestCase):
+    def test_start_session_uses_defaults_and_returns_started_session(self) -> None:
+        repository = Mock()
+        app = create_app()
+        app.dependency_overrides[get_session_repository] = lambda: repository
+        client = TestClient(app)
+
+        response = client.post("/sessions/start")
+
+        self.assertEqual(response.status_code, 201)
+        payload = response.json()
+        self.assertEqual(payload["status"], "started")
+        self.assertTrue(payload["session_id"])
+        self.assertTrue(payload["started_at"])
+        repository.create_session.assert_called_once_with(
+            payload["session_id"],
+            {
+                "user_id": "anonymous",
+                "source_language": "ja",
+                "target_language": "en",
+                "status": "started",
+                "started_at": payload["started_at"],
+            },
+        )
+
+    def test_start_session_accepts_language_overrides(self) -> None:
+        repository = Mock()
+        app = create_app()
+        app.dependency_overrides[get_session_repository] = lambda: repository
+        client = TestClient(app)
+
+        response = client.post(
+            "/sessions/start",
+            json={"source_language": "ko", "target_language": "en"},
+        )
+
+        self.assertEqual(response.status_code, 201)
+        payload = response.json()
+        repository.create_session.assert_called_once_with(
+            payload["session_id"],
+            {
+                "user_id": "anonymous",
+                "source_language": "ko",
+                "target_language": "en",
+                "status": "started",
+                "started_at": payload["started_at"],
+            },
+        )

--- a/frontend/app/globals.css
+++ b/frontend/app/globals.css
@@ -10,6 +10,9 @@
   --shadow: 0 22px 60px rgba(57, 40, 16, 0.12);
   --brand: #b65c2e;
   --brand-strong: #8f431d;
+  --success-bg: rgba(80, 122, 76, 0.12);
+  --success-text: #355b2c;
+  --error: #a33f2a;
 }
 
 * {
@@ -133,18 +136,70 @@ h1 {
   box-shadow: 0 14px 32px rgba(143, 67, 29, 0.28);
   transition:
     transform 160ms ease,
-    box-shadow 160ms ease;
+    box-shadow 160ms ease,
+    opacity 160ms ease;
 }
 
-.start-button:hover {
+.start-button:hover:not(:disabled) {
   transform: translateY(-1px);
   box-shadow: 0 16px 36px rgba(143, 67, 29, 0.34);
+}
+
+.start-button:disabled {
+  cursor: wait;
+  opacity: 0.78;
 }
 
 .button-note {
   margin: 0;
   font-size: 0.92rem;
   color: var(--muted);
+}
+
+.error-note {
+  margin: 0;
+  color: var(--error);
+  font-size: 0.92rem;
+}
+
+.session-state {
+  display: grid;
+  gap: 14px;
+  padding: 18px;
+  border-radius: 18px;
+  background: var(--success-bg);
+}
+
+.session-label {
+  margin: 0;
+  color: var(--success-text);
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.session-details {
+  margin: 0;
+  display: grid;
+  gap: 12px;
+}
+
+.session-details div {
+  display: grid;
+  gap: 4px;
+}
+
+.session-details dt {
+  color: var(--muted);
+  font-size: 0.84rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.session-details dd {
+  margin: 0;
+  color: var(--text);
+  font-size: 0.98rem;
+  word-break: break-word;
 }
 
 @media (max-width: 760px) {

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,4 +1,54 @@
+"use client";
+
+import { useState } from "react";
+
+type StartSessionResponse = {
+  session_id: string;
+  status: string;
+  started_at: string;
+};
+
+const API_BASE_URL =
+  process.env.NEXT_PUBLIC_API_BASE_URL ?? "http://localhost:8000";
+
 export default function HomePage() {
+  const [session, setSession] = useState<StartSessionResponse | null>(null);
+  const [isStarting, setIsStarting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  async function handleStartSession() {
+    setIsStarting(true);
+    setErrorMessage(null);
+
+    try {
+      const response = await fetch(`${API_BASE_URL}/sessions/start`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          source_language: "ja",
+          target_language: "en",
+        }),
+      });
+
+      if (!response.ok) {
+        throw new Error("Unable to start a session right now.");
+      }
+
+      const payload = (await response.json()) as StartSessionResponse;
+      setSession(payload);
+    } catch (error) {
+      setErrorMessage(
+        error instanceof Error
+          ? error.message
+          : "Unable to start a session right now.",
+      );
+    } finally {
+      setIsStarting(false);
+    }
+  }
+
   return (
     <main className="page-shell">
       <section className="hero-card">
@@ -14,15 +64,48 @@ export default function HomePage() {
 
         <div className="hero-panel" aria-label="Product summary">
           <div className="panel-chip">MVP</div>
-          <ul className="feature-list">
-            <li>Speak naturally first</li>
-            <li>Review personal phrases after the session</li>
-            <li>No translation-oriented workflow</li>
-          </ul>
-          <button className="start-button" type="button">
-            Start Session
-          </button>
-          <p className="button-note">Session flow placeholder for the next issue.</p>
+          {session ? (
+            <div className="session-state" aria-live="polite">
+              <p className="session-label">Session started</p>
+              <dl className="session-details">
+                <div>
+                  <dt>Session ID</dt>
+                  <dd>{session.session_id}</dd>
+                </div>
+                <div>
+                  <dt>Status</dt>
+                  <dd>{session.status}</dd>
+                </div>
+                <div>
+                  <dt>Started At</dt>
+                  <dd>{new Date(session.started_at).toLocaleString()}</dd>
+                </div>
+              </dl>
+              <p className="button-note">
+                The session is ready for the next voice flow step.
+              </p>
+            </div>
+          ) : (
+            <>
+              <ul className="feature-list">
+                <li>Speak naturally first</li>
+                <li>Review personal phrases after the session</li>
+                <li>No translation-oriented workflow</li>
+              </ul>
+              <button
+                className="start-button"
+                type="button"
+                onClick={handleStartSession}
+                disabled={isStarting}
+              >
+                {isStarting ? "Starting..." : "Start Session"}
+              </button>
+              <p className="button-note">
+                Starts an anonymous Japanese-to-English practice session.
+              </p>
+              {errorMessage ? <p className="error-note">{errorMessage}</p> : null}
+            </>
+          )}
         </div>
       </section>
     </main>


### PR DESCRIPTION
## Summary
- add `POST /sessions/start` backed by Firestore and wire up CORS so the frontend can call it
- implement session persistence helpers plus unit tests for the new repository behavior
- connect the desktop Start Session button to the API, surface error states, and show basic started-session metadata with new styles
- How to run locally: boot the backend (`uvicorn backend.app.main:create_app --reload`) and run the Next.js frontend (`npm run dev` from `frontend/`), then click Start Session to see the new state
- Assumptions: anonymous sessions with default ja → en languages are enough for this MVP scope
- Next steps: build the live microphone flow, transcript ingestion, and session completion UX once the started state exists

## Testing
- Not run (not requested)