### PR TITLE
Add transcript ingestion endpoint

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -37,6 +37,8 @@ FIRESTORE_DATABASE_ID=(default)
 ## Available routes
 
 - `GET /healthz`
+- `POST /sessions/start`
+- `POST /sessions/{session_id}/transcript`
 
 ## Firestore scaffold
 
@@ -52,7 +54,31 @@ Current scope:
 
 - Firestore client setup is centralized in `app/core/firestore.py`
 - `SessionRepository` exposes document and collection references for sessions
-- transcript entry and phrase card persistence are placeholder methods only
+- transcript entries can be written directly to Firestore under the session subcollection
+- phrase card persistence remains a placeholder for a later issue
+
+Transcript ingestion request shape:
+
+```json
+{
+  "entries": [
+    {
+      "entry_id": "optional-client-generated-id",
+      "speaker": "user",
+      "text": "I really enjoyed today",
+      "language": "ja",
+      "timestamp": "2026-03-13T10:00:00Z",
+      "turn_index": 0
+    }
+  ]
+}
+```
+
+Notes:
+
+- `entries` must include at least one transcript entry
+- `speaker` currently supports `user` and `agent`
+- `entry_id` is optional; the backend generates one when omitted
 
 Storage constraints:
 
@@ -61,5 +87,4 @@ Storage constraints:
 
 ## Notes
 
-- `app/api/routes/sessions.py` is intentionally a placeholder router for upcoming session endpoints.
 - This scaffold does not include session CRUD business logic, Gemini integration, or authentication.

--- a/backend/app/api/routes/sessions.py
+++ b/backend/app/api/routes/sessions.py
@@ -1,8 +1,9 @@
 from datetime import datetime, timezone
+from typing import Literal
 from uuid import uuid4
 
 from fastapi import APIRouter, Body, Depends, status
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 
 from app.repositories.sessions import SessionRepository
 
@@ -16,6 +17,48 @@ class StartSessionResponse(BaseModel):
     session_id: str
     status: str
     started_at: str
+
+
+class TranscriptEntryRequest(BaseModel):
+    entry_id: str | None = None
+    speaker: Literal["user", "agent"]
+    text: str
+    language: str
+    timestamp: datetime
+    turn_index: int = Field(ge=0)
+
+    @field_validator("text", "language")
+    @classmethod
+    def validate_required_text_fields(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("must not be empty")
+        return stripped
+
+    @field_validator("entry_id")
+    @classmethod
+    def validate_entry_id(cls, value: str | None) -> str | None:
+        if value is None:
+            return value
+
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("must not be empty")
+        return stripped
+
+
+class TranscriptIngestionRequest(BaseModel):
+    entries: list[TranscriptEntryRequest] = Field(min_length=1)
+
+
+class TranscriptEntryResponse(BaseModel):
+    entry_id: str
+
+
+class TranscriptIngestionResponse(BaseModel):
+    session_id: str
+    stored_count: int
+    entries: list[TranscriptEntryResponse]
 
 
 router = APIRouter(prefix="/sessions", tags=["sessions"])
@@ -50,4 +93,39 @@ def start_session(
         session_id=session_id,
         status=session_status,
         started_at=started_at,
+    )
+
+
+@router.post(
+    "/{session_id}/transcript",
+    response_model=TranscriptIngestionResponse,
+    status_code=status.HTTP_201_CREATED,
+)
+def ingest_transcript(
+    session_id: str,
+    payload: TranscriptIngestionRequest,
+    repository: SessionRepository = Depends(get_session_repository),
+) -> TranscriptIngestionResponse:
+    stored_entries: list[TranscriptEntryResponse] = []
+
+    for entry in payload.entries:
+        entry_id = entry.entry_id or str(uuid4())
+        repository.add_transcript_entry(
+            session_id,
+            entry_id,
+            {
+                "entry_id": entry_id,
+                "speaker": entry.speaker,
+                "text": entry.text,
+                "language": entry.language,
+                "timestamp": entry.timestamp.isoformat(),
+                "turn_index": entry.turn_index,
+            },
+        )
+        stored_entries.append(TranscriptEntryResponse(entry_id=entry_id))
+
+    return TranscriptIngestionResponse(
+        session_id=session_id,
+        stored_count=len(stored_entries),
+        entries=stored_entries,
     )

--- a/backend/app/repositories/sessions.py
+++ b/backend/app/repositories/sessions.py
@@ -45,9 +45,7 @@ class SessionRepository:
     def add_transcript_entry(
         self, session_id: str, entry_id: str, payload: dict[str, object]
     ) -> None:
-        raise NotImplementedError(
-            "Transcript entry persistence will be implemented in a future session issue."
-        )
+        self.list_transcript_entries_ref(session_id).document(entry_id).set(payload)
 
     def add_phrase_card(
         self, session_id: str, card_id: str, payload: dict[str, object]

--- a/backend/tests/test_firestore_scaffold.py
+++ b/backend/tests/test_firestore_scaffold.py
@@ -76,3 +76,43 @@ class FirestoreScaffoldTests(unittest.TestCase):
                 "started_at": "2026-03-13T10:00:00+00:00",
             }
         )
+
+    def test_add_transcript_entry_persists_document_in_subcollection(self) -> None:
+        entry_ref = Mock()
+        transcript_collection_ref = Mock()
+        transcript_collection_ref.document.return_value = entry_ref
+        session_ref = Mock()
+        session_ref.collection.return_value = transcript_collection_ref
+        collection_ref = Mock()
+        collection_ref.document.return_value = session_ref
+        client = Mock()
+        client.collection.return_value = collection_ref
+        repository = SessionRepository(client=client)
+
+        repository.add_transcript_entry(
+            "session-123",
+            "entry-456",
+            {
+                "entry_id": "entry-456",
+                "speaker": "user",
+                "text": "Hello",
+                "language": "ja",
+                "timestamp": "2026-03-13T10:05:00+00:00",
+                "turn_index": 0,
+            },
+        )
+
+        client.collection.assert_called_once_with("sessions")
+        collection_ref.document.assert_called_once_with("session-123")
+        session_ref.collection.assert_called_once_with("transcript_entries")
+        transcript_collection_ref.document.assert_called_once_with("entry-456")
+        entry_ref.set.assert_called_once_with(
+            {
+                "entry_id": "entry-456",
+                "speaker": "user",
+                "text": "Hello",
+                "language": "ja",
+                "timestamp": "2026-03-13T10:05:00+00:00",
+                "turn_index": 0,
+            }
+        )

--- a/backend/tests/test_sessions_api.py
+++ b/backend/tests/test_sessions_api.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import Mock
+from unittest.mock import ANY, Mock
 
 try:
     from fastapi.testclient import TestClient
@@ -61,3 +61,99 @@ class SessionApiTests(unittest.TestCase):
                 "started_at": payload["started_at"],
             },
         )
+
+    def test_ingest_transcript_stores_multiple_entries(self) -> None:
+        repository = Mock()
+        app = create_app()
+        app.dependency_overrides[get_session_repository] = lambda: repository
+        client = TestClient(app)
+
+        response = client.post(
+            "/sessions/session-123/transcript",
+            json={
+                "entries": [
+                    {
+                        "entry_id": "entry-1",
+                        "speaker": "user",
+                        "text": "I had fun today",
+                        "language": "ja",
+                        "timestamp": "2026-03-13T10:00:00Z",
+                        "turn_index": 0,
+                    },
+                    {
+                        "speaker": "agent",
+                        "text": "That sounds fun.",
+                        "language": "en",
+                        "timestamp": "2026-03-13T10:00:05Z",
+                        "turn_index": 1,
+                    },
+                ]
+            },
+        )
+
+        self.assertEqual(response.status_code, 201)
+        payload = response.json()
+        self.assertEqual(payload["session_id"], "session-123")
+        self.assertEqual(payload["stored_count"], 2)
+        self.assertEqual(payload["entries"][0]["entry_id"], "entry-1")
+        self.assertTrue(payload["entries"][1]["entry_id"])
+        repository.add_transcript_entry.assert_any_call(
+            "session-123",
+            "entry-1",
+            {
+                "entry_id": "entry-1",
+                "speaker": "user",
+                "text": "I had fun today",
+                "language": "ja",
+                "timestamp": "2026-03-13T10:00:00+00:00",
+                "turn_index": 0,
+            },
+        )
+        repository.add_transcript_entry.assert_any_call(
+            "session-123",
+            ANY,
+            {
+                "entry_id": ANY,
+                "speaker": "agent",
+                "text": "That sounds fun.",
+                "language": "en",
+                "timestamp": "2026-03-13T10:00:05+00:00",
+                "turn_index": 1,
+            },
+        )
+        self.assertEqual(repository.add_transcript_entry.call_count, 2)
+
+    def test_ingest_transcript_rejects_missing_entries(self) -> None:
+        repository = Mock()
+        app = create_app()
+        app.dependency_overrides[get_session_repository] = lambda: repository
+        client = TestClient(app)
+
+        response = client.post("/sessions/session-123/transcript", json={"entries": []})
+
+        self.assertEqual(response.status_code, 422)
+        repository.add_transcript_entry.assert_not_called()
+
+    def test_ingest_transcript_rejects_invalid_entry_fields(self) -> None:
+        repository = Mock()
+        app = create_app()
+        app.dependency_overrides[get_session_repository] = lambda: repository
+        client = TestClient(app)
+
+        response = client.post(
+            "/sessions/session-123/transcript",
+            json={
+                "entries": [
+                    {
+                        "speaker": "system",
+                        "text": "   ",
+                        "language": "",
+                        "timestamp": "not-a-timestamp",
+                        "turn_index": -1,
+                    }
+                ]
+            },
+        )
+
+        self.assertEqual(response.status_code, 422)
+        repository.add_transcript_entry.assert_not_called()


### PR DESCRIPTION
Summary
- Implement POST `/sessions/{session_id}/transcript` so callers can submit one or more transcript entries with speaker, text, language, timestamp, and turn index.
- Validate required fields and surface clear errors when payloads are missing data before persisting anything.
- Persist each entry to Firestore under `sessions/{session_id}/transcript_entries/{entry_id}` using the existing client setup; assumes the Firestore client/credentials are configured by the running backend.
- Verify locally by running the backend against the dev Firestore emulator (or real project) and POSTing a sample payload to `/sessions/abc/transcript`.
- Follow-up: hook this ingestion into live session streaming once the real-time audio path is ready.

Testing
- Not run (not requested)